### PR TITLE
limit the amount note_v to max_money

### DIFF
--- a/sapling_key_components.py
+++ b/sapling_key_components.py
@@ -102,10 +102,12 @@ class SpendingKey(DerivedAkNk, DerivedIvk):
 def main():
     args = render_args()
 
+    max_money = 2100000000000000
+
     test_vectors = []
     for i in range(0, 10):
         sk = SpendingKey(bytes([i] * 32))
-        note_v = (2548793025584392057432895043257984320*i) % 2**64
+        note_v = (2548793025584392057432895043257984320*i) % max_money
         note_r = Fr(8890123457840276890326754358439057438290574382905).exp(i+1)
         note_cm = note_commit(
             note_r,


### PR DESCRIPTION
After the addition of Amount to librustzcash, we enforced it everywhere in our codebase (Sapling integration in Tezos). 
We recently generated some vectors with these scripts and they were failing, hence this MR.