### PR TITLE
Updates for new NU5 testnet consensus rules

### DIFF
--- a/orchard_commitments.py
+++ b/orchard_commitments.py
@@ -24,7 +24,7 @@ def rcv_trapdoor(rand):
 # https://zips.z.cash/protocol/nu5.pdf#concretesinsemillacommit
 def sinsemilla_commit(r: Scalar, D, M):
     assert isinstance(r, Scalar)
-    return sinsemilla_hash_to_point(D + b"-M", M).checked_incomplete_add(
+    return sinsemilla_hash_to_point(D + b"-M", M) + (
         group_hash(D + b"-r", b"") * r
     )
 

--- a/zip_0244.py
+++ b/zip_0244.py
@@ -309,7 +309,7 @@ def main():
         return bytes(ret)
     rand = Rand(randbytes)
 
-    consensusBranchId = 0xF919A198 # NU5
+    consensusBranchId = 0x37519621 # NU5
 
     test_vectors = []
     for _ in range(10):


### PR DESCRIPTION
The ZIP 244 test vectors are altered as a result of changing the
consensus branch ID.