### PR TITLE
Encode UAs/UVKs in ascending typecode order

### DIFF
--- a/unified_full_viewing_keys.py
+++ b/unified_full_viewing_keys.py
@@ -87,8 +87,8 @@ def main():
         ufvk = encode_unified(rng, receivers, "uview")
 
         expected_lengths = {
-            P2PKH_ITEM: 65, 
-            SAPLING_ITEM: 128, 
+            P2PKH_ITEM: 65,
+            SAPLING_ITEM: 128,
             ORCHARD_ITEM: 96,
             unknown_tc: unknown_len
         }


### PR DESCRIPTION
This updates test vectors for the change to ZIP 316 in https://github.com/zcash/zips/commit/06b945bfe742a017657a402a067277408421f57f .