### PR TITLE
Revert a change made in #53, so that the license and contribution preamble is visible in `README.md`

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018-2019 Electric Coin Company
+Copyright (c) 2018-2021 The Electric Coin Company
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -9,4 +9,16 @@ Requirements:
 
 ## License
 
-This repository is [MIT/Apache 2.0 dual-licensed](COPYING.md).
+Licensed under either of
+
+ * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally
+submitted for inclusion in the work by you, as defined in the Apache-2.0
+license, shall be dual licensed as above, without any additional terms or
+conditions.


### PR DESCRIPTION
Addresses https://github.com/zcash-hackworks/zcash-test-vectors/pull/53/files#r751745511